### PR TITLE
Preserve global-mean variability in EOF noise basis

### DIFF
--- a/src/meteor/noise_generator.py
+++ b/src/meteor/noise_generator.py
@@ -55,14 +55,18 @@ class MeteorNoiseGenerator:
         Whether the model has been fitted
     """
 
-    def __init__(self, n_modes=10, lag_order=2, use_exog="temp_only"):
+    def __init__(self, n_modes=40, lag_order=2, use_exog="temp_only", weight_eofs=True):
         """
         Initialize the noise generator.
 
         Parameters
         ----------
-        n_modes : int, default 10
-            Number of PCA modes to retain
+        n_modes : int, default 40
+            Number of PCA modes to retain. The default of 40 (raised from 10)
+            captures ~90%+ of global-mean temperature variability; lower values
+            truncate the spatially coherent modes that carry the global signal
+            and suppress global-mean variance (point/regional variance is far
+            less sensitive to truncation).
         lag_order : int, default 2
             Lag order for VARX model
         use_exog : str, default 'temp_only'
@@ -70,10 +74,22 @@ class MeteorNoiseGenerator:
             - 'all': Use temperature, annual_cos, annual_sin (original behavior)
             - 'temp_only': Use only temperature (recommended to avoid spurious seasonality)
             - 'none': Pure VAR with no exogenous variables
+        weight_eofs : bool, default True
+            If True, area-weight the anomaly field by sqrt(cos(latitude)) before
+            fitting the EOF/PCA basis, so PCA optimizes area-weighted variance
+            (consistent with the global mean) rather than raw per-gridcell
+            variance. This stops dense high-latitude cells from dominating the
+            leading EOFs and pushing the global-mean-carrying structure into
+            trailing (truncated) modes. Set False to recover the legacy
+            unweighted behavior.
         """
         self.n_modes = n_modes
         self.lag_order = lag_order
         self.use_exog = use_exog
+        self.weight_eofs = weight_eofs
+        # sqrt(cos-lat) weights applied to the EOF basis (set during fit when
+        # weight_eofs is True; None means the basis is in raw gridcell space).
+        self.eof_weights = None
         self.seasonal_model = None
         self.pca = None
         self.varx_results = None
@@ -322,7 +338,23 @@ class MeteorNoiseGenerator:
         else:
             anomalies = ds[variable_name].mean(dim=["ens"]) - seasonal_cycle_fit_xr
         # Fit PCA to anomalies
-        anomalies_flat = anomalies.stack(space=("lat", "lon")).data
+        anomalies_stacked = anomalies.stack(space=("lat", "lon"))
+        anomalies_flat = anomalies_stacked.data
+
+        if self.weight_eofs:
+            # Area-weight the basis by sqrt(cos-lat) so PCA optimizes
+            # area-weighted variance (consistent with the global mean) instead
+            # of raw per-gridcell variance. cos-lat is floored to keep the
+            # weights strictly positive so components can be returned to
+            # physical units (see _physical_components); pole cells carry
+            # ~zero weight and contribute ~zero anomaly.
+            lat_per_cell = anomalies_stacked["lat"].values
+            self.eof_weights = np.sqrt(
+                np.clip(np.cos(np.deg2rad(lat_per_cell)), 1e-6, None)
+            )
+            anomalies_flat = anomalies_flat * self.eof_weights
+        else:
+            self.eof_weights = None
 
         self.pca = PCA(n_components=self.n_modes)
         pcs = self.pca.fit_transform(anomalies_flat)
@@ -533,7 +565,7 @@ class MeteorNoiseGenerator:
             synthetic_pcs = self._generate_stochastic_pcs(X_exog, n_time)
 
             # Reconstruct anomalies (NumPy)
-            reconstructed_anomalies = synthetic_pcs @ self.pca.components_
+            reconstructed_anomalies = synthetic_pcs @ self._physical_components()
             reconstructed_anomalies_reshaped = reconstructed_anomalies.reshape(
                 n_time, n_lat, n_lon
             )
@@ -671,6 +703,26 @@ class MeteorNoiseGenerator:
 
         return lat_idx, lon_idx
 
+    def _physical_components(self):
+        """
+        EOF components in physical (unweighted) gridcell space.
+
+        When the basis was fit with area weighting (``self.eof_weights`` set),
+        the stored PCA components live in sqrt(cos-lat)-weighted space; dividing
+        by the weights returns them to physical units so reconstructions and
+        regional projections are correct. Falls back to the raw components for
+        models fit with ``weight_eofs=False`` and for backward compatibility
+        with pickles saved before weighting was introduced.
+
+        Returns
+        -------
+        np.ndarray
+            EOF components, shape (n_modes, n_space), in physical units.
+        """
+        if getattr(self, "eof_weights", None) is None:
+            return self.pca.components_
+        return self.pca.components_ / self.eof_weights
+
     def _get_point_eof_values(self, lat, lon):
         """
         Get EOF values at a specific point (no averaging).
@@ -700,7 +752,7 @@ class MeteorNoiseGenerator:
         # Get EOFs reshaped to spatial grid
         n_lat = len(self.coords["lat"])
         n_lon = len(self.coords["lon"])
-        eof_components = self.pca.components_.reshape(self.n_modes, n_lat, n_lon)
+        eof_components = self._physical_components().reshape(self.n_modes, n_lat, n_lon)
 
         # Extract values at the point (no averaging needed)
         eof_point_values = eof_components[:, lat_idx, lon_idx]
@@ -739,7 +791,7 @@ class MeteorNoiseGenerator:
         n_lon = len(self.coords["lon"])
 
         # Get EOFs reshaped to spatial grid (n_modes, n_lat, n_lon)
-        eof_components = self.pca.components_.reshape(self.n_modes, n_lat, n_lon)
+        eof_components = self._physical_components().reshape(self.n_modes, n_lat, n_lon)
         if region_mask is None and region != "global":
             region_mask = self._get_ar6_region_mask(region)
 
@@ -1070,6 +1122,8 @@ class MeteorNoiseGenerator:
             "n_modes": self.n_modes,
             "lag_order": self.lag_order,
             "use_exog": self.use_exog,
+            "weight_eofs": self.weight_eofs,
+            "eof_weights": self.eof_weights,
             "seasonal_model": self.seasonal_model,
             "pca": self.pca,
             "varx_results": self.varx_results,
@@ -1100,6 +1154,10 @@ class MeteorNoiseGenerator:
         self.use_exog = model_data.get(
             "use_exog", "all"
         )  # Default to 'all' for backward compatibility
+        # Backward compatibility: pickles predating area weighting have neither
+        # key, which correctly restores the legacy unweighted behavior.
+        self.weight_eofs = model_data.get("weight_eofs", False)
+        self.eof_weights = model_data.get("eof_weights", None)
         self.seasonal_model = model_data["seasonal_model"]
         self.pca = model_data["pca"]
         self.varx_results = model_data["varx_results"]
@@ -1117,13 +1175,14 @@ def train_noise_model_from_cmip6(
     experiments,
     model_name,
     variable_name,
-    n_modes=10,
+    n_modes=40,
     lag_order=2,
     cache_dir=None,
     custom_global_temp=None,
     use_picontrol_baseline=True,
     save_diagnostics=False,
     use_exog="temp_only",
+    weight_eofs=True,
     verbose=False,
 ):
     """
@@ -1142,7 +1201,7 @@ def train_noise_model_from_cmip6(
         Name of the climate model (must be available in data_getter)
     variable_name : str
         Variable to model (e.g., 'tas', 'pr')
-    n_modes : int, default 10
+    n_modes : int, default 40
         Number of PCA modes to retain
     lag_order : int, default 2
         Lag order for VARX model
@@ -1168,6 +1227,10 @@ def train_noise_model_from_cmip6(
         - 'all': Use temperature, annual_cos, annual_sin (may cause spurious seasonality)
         - 'temp_only': Use only temperature (recommended)
         - 'none': Pure VAR with no exogenous variables
+    weight_eofs : bool, default True
+        If True, area-weight the anomaly field by sqrt(cos(latitude)) before
+        fitting the EOF basis so global-mean variability is preserved. See
+        MeteorNoiseGenerator for details. Set False for legacy unweighted EOFs.
     verbose : bool, default False
         If True, prints variance decomposition statistics after fitting.
 
@@ -1212,7 +1275,7 @@ def train_noise_model_from_cmip6(
 
     # Create and fit noise generator
     noise_gen = MeteorNoiseGenerator(
-        n_modes=n_modes, lag_order=lag_order, use_exog=use_exog
+        n_modes=n_modes, lag_order=lag_order, use_exog=use_exog, weight_eofs=weight_eofs
     )
     noise_gen.fit(
         monthly_data,
@@ -1238,12 +1301,13 @@ def train_multiple_noise_models_from_cmip6(
     experiments,
     models=None,
     variables=None,
-    n_modes=10,
+    n_modes=40,
     lag_order=2,
     cache_dir=None,
     custom_global_temp=None,
     use_picontrol_baseline=True,
     use_exog="temp_only",
+    weight_eofs=True,
 ):
     """
     Train noise generators for multiple model/variable combinations.
@@ -1261,7 +1325,7 @@ def train_multiple_noise_models_from_cmip6(
         List of models to train. If None, uses all available models.
     variables : list, optional
         List of variables to train. If None, uses all fields in data getter.
-    n_modes : int, default 10
+    n_modes : int, default 40
         Number of PCA modes to retain
     lag_order : int, default 2
         Lag order for VARX model
@@ -1279,6 +1343,10 @@ def train_multiple_noise_models_from_cmip6(
         - 'all': Use temperature, annual_cos, annual_sin (may cause spurious seasonality)
         - 'temp_only': Use only temperature (recommended)
         - 'none': Pure VAR with no exogenous variables
+    weight_eofs : bool, default True
+        If True, area-weight the anomaly field by sqrt(cos(latitude)) before
+        fitting the EOF basis so global-mean variability is preserved. See
+        MeteorNoiseGenerator for details. Set False for legacy unweighted EOFs.
 
     Returns
     -------
@@ -1326,6 +1394,7 @@ def train_multiple_noise_models_from_cmip6(
                     custom_global_temp=custom_global_temp,
                     use_picontrol_baseline=use_picontrol_baseline,
                     use_exog=use_exog,
+                    weight_eofs=weight_eofs,
                 )
                 noise_models[model][variable] = noise_gen
             except Exception as e:  # pylint: disable=broad-exception-caught

--- a/tests/unit/test_noise_generator.py
+++ b/tests/unit/test_noise_generator.py
@@ -23,8 +23,9 @@ def test_meteor_noise_generator_initialization():
     assert hasattr(generator, "varx_results")
     assert hasattr(generator, "fitted")
     assert generator.fitted is False
-    assert generator.n_modes == 10  # default value
+    assert generator.n_modes == 40  # default value
     assert generator.lag_order == 2  # default value
+    assert generator.weight_eofs is True  # area-weighting on by default
 
     # Test error handling with uninitiated state
     with pytest.raises(ValueError, match="Invalid use_exog value:"):
@@ -518,3 +519,87 @@ def test_generate_realization_unfitted_error():
 
     with pytest.raises(ValueError, match="Model must be fitted before generating"):
         generator.generate_realization(test_trajectory)
+
+
+def _make_training_dataset(nt=120, nla=8, nlo=12):
+    """Small monthly dataset spanning the full pole-to-pole latitude range."""
+    time = np.arange(nt)
+    lats = np.linspace(-90, 90, nla)  # includes exact poles (cos lat == 0)
+    lons = np.linspace(0, 360, nlo, endpoint=False)
+    rng = np.random.default_rng(0)
+    data = (
+        rng.standard_normal((nt, nla, nlo, 1)) * 0.5
+        + np.cos(np.deg2rad(lats))[None, :, None, None]
+        * np.sin(time / 12.0)[:, None, None, None]
+    )
+    da = xr.DataArray(
+        data,
+        coords={"month": time, "lat": lats, "lon": lons, "ens": [0]},
+        dims=["month", "lat", "lon", "ens"],
+        name="tas",
+    )
+    return xr.Dataset({"tas": da})
+
+
+def test_eof_area_weighting_default_and_physical_components():
+    """Area weighting is on by default, sets weights, and reconstructs finite
+    fields even at the poles (where cos(lat) == 0)."""
+    ds = _make_training_dataset()
+    gen = MeteorNoiseGenerator(n_modes=4, lag_order=1)  # weight_eofs defaults True
+    assert gen.weight_eofs is True
+    gen.fit(ds, "tas")
+
+    n_space = ds.sizes["lat"] * ds.sizes["lon"]
+    assert gen.eof_weights is not None
+    assert gen.eof_weights.shape == (n_space,)
+    assert np.all(gen.eof_weights > 0)  # floored, so poles are nonzero
+
+    # physical components are the stored components un-weighted, and differ
+    # from the raw (weighted-space) components
+    phys = gen._physical_components()
+    assert phys.shape == gen.pca.components_.shape
+    assert not np.allclose(phys, gen.pca.components_)
+
+    traj = np.linspace(0, 2, ds.sizes["month"])
+    grid = gen.generate_realization(traj, n_realizations=1)
+    assert np.isfinite(grid.values).all()  # no inf/nan from pole division
+    glob = gen.generate_regional_mean_realizations(
+        traj, region="global", n_realizations=2, return_numpy=True
+    )
+    assert np.isfinite(glob).all()
+    pole = gen.generate_regional_mean_realizations(
+        traj, lat=90.0, lon=0.0, n_realizations=1, return_numpy=True
+    )
+    assert np.isfinite(np.asarray(pole)).all()
+
+
+def test_eof_weighting_disabled_matches_legacy():
+    """weight_eofs=False keeps the basis in raw gridcell space (legacy behavior)."""
+    ds = _make_training_dataset()
+    gen = MeteorNoiseGenerator(n_modes=4, lag_order=1, weight_eofs=False)
+    gen.fit(ds, "tas")
+    assert gen.eof_weights is None
+    assert np.allclose(gen._physical_components(), gen.pca.components_)
+
+
+def test_eof_weights_survive_save_load(tmp_path):
+    """Saving and loading preserves weighting state and reproduces output."""
+    ds = _make_training_dataset()
+    gen = MeteorNoiseGenerator(n_modes=4, lag_order=1)
+    gen.fit(ds, "tas")
+
+    fp = str(tmp_path / "model.pkl")
+    gen.save_model(fp)
+    loaded = MeteorNoiseGenerator()
+    loaded.load_model(fp)
+    assert loaded.weight_eofs is True
+    assert np.allclose(loaded.eof_weights, gen.eof_weights)
+
+    traj = np.linspace(0, 2, ds.sizes["month"])
+    a = gen.generate_regional_mean_realizations(
+        traj, region="global", n_realizations=1, random_seed=7, return_numpy=True
+    )
+    b = loaded.generate_regional_mean_realizations(
+        traj, region="global", n_realizations=1, random_seed=7, return_numpy=True
+    )
+    assert np.allclose(a, b)

--- a/tests/unit/test_noise_generator.py
+++ b/tests/unit/test_noise_generator.py
@@ -162,8 +162,8 @@ def test_complex_scenarios():
         name="precipitation",
     )
 
-    # Test with complex datasets
-    generator = noise_generator.MeteorNoiseGenerator()
+    # Test with complex datasets (small 5x6 grid -> keep n_modes <= n_gridcells)
+    generator = noise_generator.MeteorNoiseGenerator(n_modes=3)
 
     # Test fitting with multiple variables
     training_data = xr.Dataset({"tas": temp_da, "pr": precip_da})
@@ -325,7 +325,8 @@ def test_advanced_noise_generation():
     )
     training_data = xr.Dataset({"tas": temp_da})
 
-    generator = noise_generator.MeteorNoiseGenerator()
+    # Small 3x4 grid -> keep n_modes <= n_gridcells
+    generator = noise_generator.MeteorNoiseGenerator(n_modes=3)
 
     # Test the fitting process
     generator.fit(training_data, "tas")


### PR DESCRIPTION
## Problem

Simulated **global-mean** internal variability was significantly weaker than the target ESM, even though **point/regional** variability looked realistic. 

## Diagnosis

Variance-decomposition (NorESM2-MM `tas`, historical+ssp245) indicates this is due to EOF basis construction
The global mean is `Σ_k PC_k(t) · ⟨EOF_k⟩_area`, so it samples a *different* projection of the PC covariance than point variance does. Two issues:

1. **Unweighted PCA.** The basis was fit on the raw flattened grid, optimizing per-gridcell variance. Dense high-latitude cells dominate the leading EOFs, excluding regions carrying the global mean signal.
2. **Low default mode count.** Global-mean variance retained by the basis:

| n_modes | retained (unweighted, as-built) | retained (area-weighted) |
|--------:|--------:|--------:|
| 10 *(old default)* | 45% | 70% |
| 40 *(interface default)* | 91% | 95% |
| 80 | 97% | 98% |

VAR-X generator correctly reproduces whatever the basis retains , confirming the suppression is purely truncation 

## Changes

- **Default `n_modes` 10 → 40** for temperature (matches the existing interface default).
- **Area-weight anomalies by √cos(lat) before PCA by default** (`weight_eofs=True`). At 40 modes this lifts `tas` global-variance retention 91% → 95%, and helps most at low mode counts (45% → 70% at 10).

EOF components are stored in weighted space and converted back to physical units via `_physical_components()` for reconstruction, point extraction, and regional projection. `cos(lat)` is floored so poles stay finite. `weight_eofs` and the weights are persisted in `save_model`; **older pickles load as unweighted (legacy behavior preserved)**, and `weight_eofs=False` recovers the previous behavior.

## Tests

Updated the default-value assertion and added three tests covering weighting-on round-trip (incl. exact poles), `weight_eofs=False` legacy parity, and save/load persistence.

## Note on precipitation

The same diagnostic shows `pr` is far more severely affected (only ~41% retained at 40 modes) - likely needs a dedicated treatment if global mean precip variability is a target concern.