### PR TITLE
Preserve low-frequency global variability: default to pure VAR (use_exog='none')

### DIFF
--- a/src/meteor/meteor_interface.py
+++ b/src/meteor/meteor_interface.py
@@ -45,7 +45,14 @@ def _get_default_config(variable):
 
     # Variable-specific defaults
     if variable == "tas":
-        config["use_exog"] = "all"
+        # 'none' (pure VAR): using t_glob as a VAR-X exogenous regressor absorbs
+        # the persistent low-frequency global variability into the deterministic
+        # forced term, so it is lost at generation (the prescribed trajectory has
+        # no internal variability) -- the noise becomes white and annual/decadal
+        # global variance collapses ~2.5x. The temperature-dependent mean/seasonal
+        # response is already captured by the seasonal model, so the exog is
+        # redundant here. See MeteorNoiseGenerator.use_exog.
+        config["use_exog"] = "none"
         config["transform"] = False
     elif variable == "pr":
         config["use_exog"] = "none"

--- a/src/meteor/noise_generator.py
+++ b/src/meteor/noise_generator.py
@@ -55,7 +55,7 @@ class MeteorNoiseGenerator:
         Whether the model has been fitted
     """
 
-    def __init__(self, n_modes=40, lag_order=2, use_exog="temp_only", weight_eofs=True):
+    def __init__(self, n_modes=40, lag_order=2, use_exog="none", weight_eofs=True):
         """
         Initialize the noise generator.
 
@@ -69,11 +69,23 @@ class MeteorNoiseGenerator:
             less sensitive to truncation).
         lag_order : int, default 2
             Lag order for VARX model
-        use_exog : str, default 'temp_only'
+        use_exog : str, default 'none'
             Exogenous variables to use in VARX model:
-            - 'all': Use temperature, annual_cos, annual_sin (original behavior)
-            - 'temp_only': Use only temperature (recommended to avoid spurious seasonality)
-            - 'none': Pure VAR with no exogenous variables
+            - 'none': Pure VAR with no exogenous variables (recommended).
+            - 'temp_only': Use only temperature.
+            - 'all': Use temperature, annual_cos, annual_sin (original behavior).
+
+            'none' is the default because using the smoothed global temperature
+            (t_glob) as an exogenous regressor absorbs the persistent
+            low-frequency global variability into the deterministic forced term.
+            At generation t_glob is the prescribed (smooth, internally
+            invariant) trajectory, so that power is not regenerated: the noise
+            becomes temporally white and annual/decadal global-mean variance
+            collapses (~2.5x too small for tas). The temperature-dependent
+            mean and seasonal response is already captured by the seasonal
+            model, so the exog regressor is redundant as well as harmful to
+            internal variability. 'temp_only'/'all' are retained for backward
+            compatibility but suppress low-frequency global variability.
         weight_eofs : bool, default True
             If True, area-weight the anomaly field by sqrt(cos(latitude)) before
             fitting the EOF/PCA basis, so PCA optimizes area-weighted variance
@@ -1181,7 +1193,7 @@ def train_noise_model_from_cmip6(
     custom_global_temp=None,
     use_picontrol_baseline=True,
     save_diagnostics=False,
-    use_exog="temp_only",
+    use_exog="none",
     weight_eofs=True,
     verbose=False,
 ):
@@ -1222,11 +1234,14 @@ def train_noise_model_from_cmip6(
         model.diagnostic_X_features, model.diagnostic_t_glob, model.diagnostic_time,
         model.diagnostic_seasonal_coef, model.diagnostic_seasonal_intercept,
         and model.diagnostic_Y_data.
-    use_exog : str, default 'temp_only'
+    use_exog : str, default 'none'
         Exogenous variables to use in VARX model:
+        - 'none': Pure VAR with no exogenous variables (recommended; preserves
+          low-frequency global variability)
+        - 'temp_only': Use only temperature
         - 'all': Use temperature, annual_cos, annual_sin (may cause spurious seasonality)
-        - 'temp_only': Use only temperature (recommended)
-        - 'none': Pure VAR with no exogenous variables
+        See MeteorNoiseGenerator for why t_glob as an exog regressor suppresses
+        global-mean internal variability.
     weight_eofs : bool, default True
         If True, area-weight the anomaly field by sqrt(cos(latitude)) before
         fitting the EOF basis so global-mean variability is preserved. See
@@ -1306,7 +1321,7 @@ def train_multiple_noise_models_from_cmip6(
     cache_dir=None,
     custom_global_temp=None,
     use_picontrol_baseline=True,
-    use_exog="temp_only",
+    use_exog="none",
     weight_eofs=True,
 ):
     """
@@ -1338,11 +1353,14 @@ def train_multiple_noise_models_from_cmip6(
         Whether to use piControl data as baseline for temperature anomalies.
         This ensures consistency with pattern scaling.
         If False, falls back to using first 42 years of training data.
-    use_exog : str, default 'temp_only'
+    use_exog : str, default 'none'
         Exogenous variables to use in VARX model:
+        - 'none': Pure VAR with no exogenous variables (recommended; preserves
+          low-frequency global variability)
+        - 'temp_only': Use only temperature
         - 'all': Use temperature, annual_cos, annual_sin (may cause spurious seasonality)
-        - 'temp_only': Use only temperature (recommended)
-        - 'none': Pure VAR with no exogenous variables
+        See MeteorNoiseGenerator for why t_glob as an exog regressor suppresses
+        global-mean internal variability.
     weight_eofs : bool, default True
         If True, area-weight the anomaly field by sqrt(cos(latitude)) before
         fitting the EOF basis so global-mean variability is preserved. See

--- a/tests/unit/test_meteor_interface.py
+++ b/tests/unit/test_meteor_interface.py
@@ -58,7 +58,9 @@ def test_get_default_config():
     assert tas_config["n_modes_noise"] == 40
     assert tas_config["lag_order"] == 2
     assert tas_config["training_scenario"] == "ssp245"
-    assert tas_config["use_exog"] == "all"
+    # 'none': t_glob as a VAR-X exog regressor whitens the noise and collapses
+    # low-frequency global variability (see MeteorNoiseGenerator.use_exog)
+    assert tas_config["use_exog"] == "none"
     assert not tas_config["transform"]
 
     pr_config = _get_default_config("pr")

--- a/tests/unit/test_noise_generator.py
+++ b/tests/unit/test_noise_generator.py
@@ -26,6 +26,9 @@ def test_meteor_noise_generator_initialization():
     assert generator.n_modes == 40  # default value
     assert generator.lag_order == 2  # default value
     assert generator.weight_eofs is True  # area-weighting on by default
+    # pure VAR by default: t_glob exog whitens the noise and collapses
+    # low-frequency global variability
+    assert MeteorNoiseGenerator().use_exog == "none"
 
     # Test error handling with uninitiated state
     with pytest.raises(ValueError, match="Invalid use_exog value:"):


### PR DESCRIPTION
## Problem

After the EOF-weighting fix (#74), the **monthly** global-mean tas variance was correct, but the **annual/decadal** global variability was still ~2.5× too small. The FastMIP outputs showed annual global tas internal std ≈ 0.035 K versus a target (CanESM5 piControl) of ≈ 0.089 K. The generated noise is temporally **white/anti-persistent** (lag‑1 autocorrelation ≈ −0.1), whereas real global‑mean tas is strongly **red** (lag‑1 ≈ +0.57) — so annual averaging collapses it.

## Diagnosis

Localized stage-by-stage (CanESM5 tas, validated against piControl using the real noise-model code):

| stage | annual std | lag‑1 autocorr |
|---|---|---|
| target (piControl) | 0.089 K | +0.57 |
| training anomaly global mean | 0.081 K | +0.56 (red) |
| in‑sample retained PCs → global | 0.074 K | +0.51 (red) |
| VAR‑X generated, `use_exog='all'` (old tas default) | 0.038 K | +0.18 (white) |
| **VAR‑X generated, `use_exog='none'`** | **0.076 K** | **+0.53 (red)** |

So neither the EOF basis nor the seasonal `t_glob` removal destroys persistence — both upstream stages are red. The whitening happens **only** in the VAR‑X, and **only** when `t_glob` is used as an exogenous regressor: it absorbs the persistent low‑frequency global variability into the deterministic forced term, which at generation is the smooth prescribed FAIR/pattern trajectory (no internal variability) → that power is never regenerated. `lag_order` barely matters; `use_exog='temp_only'` is even worse and goes numerically unstable at lag 12.

## Fix

Default to **pure VAR (`use_exog='none'`)**:
- `MeteorNoiseGenerator` and `train_*_from_cmip6`: default `use_exog` `'temp_only'` → `'none'`.
- interface `_get_default_config`: tas `'all'` → `'none'` (pr was already `'none'`).

The temperature-dependent mean/seasonal response is already captured by the seasonal model, so the exog regressor is redundant *and* harmful to internal variability. `'temp_only'`/`'all'` remain available (documented as suppressing low-frequency global variability).

Result: CanESM5 annual global std → 86% of target (ACCESS-ESM1-5 → 79%), persistence restored (lag‑1 +0.53), **monthly variance unchanged**.

## Tests

Updated default-config / default-constructor assertions; full unit suite passes (247 passed). Note: existing models cached with `use_exog='all'` must be **retrained** (or cleared) to benefit — the cache validator keys on `n_modes`/`lag_order`, not `use_exog`/`weight_eofs` (separate latent issue worth a follow-up guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)