### PR TITLE
pulling ben's exog fix into fastmip branch

### DIFF
--- a/src/meteor/meteor_interface.py
+++ b/src/meteor/meteor_interface.py
@@ -45,7 +45,14 @@ def _get_default_config(variable):
 
     # Variable-specific defaults
     if variable == "tas":
-        config["use_exog"] = "all"
+        # 'none' (pure VAR): using t_glob as a VAR-X exogenous regressor absorbs
+        # the persistent low-frequency global variability into the deterministic
+        # forced term, so it is lost at generation (the prescribed trajectory has
+        # no internal variability) -- the noise becomes white and annual/decadal
+        # global variance collapses ~2.5x. The temperature-dependent mean/seasonal
+        # response is already captured by the seasonal model, so the exog is
+        # redundant here. See MeteorNoiseGenerator.use_exog.
+        config["use_exog"] = "none"
         config["transform"] = False
     elif variable == "pr":
         config["use_exog"] = "none"

--- a/src/meteor/noise_generator.py
+++ b/src/meteor/noise_generator.py
@@ -55,7 +55,7 @@ class MeteorNoiseGenerator:
         Whether the model has been fitted
     """
 
-    def __init__(self, n_modes=40, lag_order=2, use_exog="temp_only", weight_eofs=True):
+    def __init__(self, n_modes=40, lag_order=2, use_exog="none", weight_eofs=True):
         """
         Initialize the noise generator.
 
@@ -69,11 +69,23 @@ class MeteorNoiseGenerator:
             less sensitive to truncation).
         lag_order : int, default 2
             Lag order for VARX model
-        use_exog : str, default 'temp_only'
+        use_exog : str, default 'none'
             Exogenous variables to use in VARX model:
-            - 'all': Use temperature, annual_cos, annual_sin (original behavior)
-            - 'temp_only': Use only temperature (recommended to avoid spurious seasonality)
-            - 'none': Pure VAR with no exogenous variables
+            - 'none': Pure VAR with no exogenous variables (recommended).
+            - 'temp_only': Use only temperature.
+            - 'all': Use temperature, annual_cos, annual_sin (original behavior).
+
+            'none' is the default because using the smoothed global temperature
+            (t_glob) as an exogenous regressor absorbs the persistent
+            low-frequency global variability into the deterministic forced term.
+            At generation t_glob is the prescribed (smooth, internally
+            invariant) trajectory, so that power is not regenerated: the noise
+            becomes temporally white and annual/decadal global-mean variance
+            collapses (~2.5x too small for tas). The temperature-dependent
+            mean and seasonal response is already captured by the seasonal
+            model, so the exog regressor is redundant as well as harmful to
+            internal variability. 'temp_only'/'all' are retained for backward
+            compatibility but suppress low-frequency global variability.
         weight_eofs : bool, default True
             If True, area-weight the anomaly field by sqrt(cos(latitude)) before
             fitting the EOF/PCA basis, so PCA optimizes area-weighted variance
@@ -1181,7 +1193,7 @@ def train_noise_model_from_cmip6(
     custom_global_temp=None,
     use_picontrol_baseline=True,
     save_diagnostics=False,
-    use_exog="temp_only",
+    use_exog="none",
     weight_eofs=True,
     verbose=False,
 ):
@@ -1222,11 +1234,14 @@ def train_noise_model_from_cmip6(
         model.diagnostic_X_features, model.diagnostic_t_glob, model.diagnostic_time,
         model.diagnostic_seasonal_coef, model.diagnostic_seasonal_intercept,
         and model.diagnostic_Y_data.
-    use_exog : str, default 'temp_only'
+    use_exog : str, default 'none'
         Exogenous variables to use in VARX model:
+        - 'none': Pure VAR with no exogenous variables (recommended; preserves
+          low-frequency global variability)
+        - 'temp_only': Use only temperature
         - 'all': Use temperature, annual_cos, annual_sin (may cause spurious seasonality)
-        - 'temp_only': Use only temperature (recommended)
-        - 'none': Pure VAR with no exogenous variables
+        See MeteorNoiseGenerator for why t_glob as an exog regressor suppresses
+        global-mean internal variability.
     weight_eofs : bool, default True
         If True, area-weight the anomaly field by sqrt(cos(latitude)) before
         fitting the EOF basis so global-mean variability is preserved. See
@@ -1306,7 +1321,7 @@ def train_multiple_noise_models_from_cmip6(
     cache_dir=None,
     custom_global_temp=None,
     use_picontrol_baseline=True,
-    use_exog="temp_only",
+    use_exog="none",
     weight_eofs=True,
 ):
     """
@@ -1338,11 +1353,14 @@ def train_multiple_noise_models_from_cmip6(
         Whether to use piControl data as baseline for temperature anomalies.
         This ensures consistency with pattern scaling.
         If False, falls back to using first 42 years of training data.
-    use_exog : str, default 'temp_only'
+    use_exog : str, default 'none'
         Exogenous variables to use in VARX model:
+        - 'none': Pure VAR with no exogenous variables (recommended; preserves
+          low-frequency global variability)
+        - 'temp_only': Use only temperature
         - 'all': Use temperature, annual_cos, annual_sin (may cause spurious seasonality)
-        - 'temp_only': Use only temperature (recommended)
-        - 'none': Pure VAR with no exogenous variables
+        See MeteorNoiseGenerator for why t_glob as an exog regressor suppresses
+        global-mean internal variability.
     weight_eofs : bool, default True
         If True, area-weight the anomaly field by sqrt(cos(latitude)) before
         fitting the EOF basis so global-mean variability is preserved. See

--- a/tests/unit/test_meteor_interface.py
+++ b/tests/unit/test_meteor_interface.py
@@ -58,7 +58,9 @@ def test_get_default_config():
     assert tas_config["n_modes_noise"] == 40
     assert tas_config["lag_order"] == 2
     assert tas_config["training_scenario"] == "ssp245"
-    assert tas_config["use_exog"] == "all"
+    # 'none': t_glob as a VAR-X exog regressor whitens the noise and collapses
+    # low-frequency global variability (see MeteorNoiseGenerator.use_exog)
+    assert tas_config["use_exog"] == "none"
     assert not tas_config["transform"]
 
     pr_config = _get_default_config("pr")

--- a/tests/unit/test_noise_generator.py
+++ b/tests/unit/test_noise_generator.py
@@ -26,6 +26,9 @@ def test_meteor_noise_generator_initialization():
     assert generator.n_modes == 40  # default value
     assert generator.lag_order == 2  # default value
     assert generator.weight_eofs is True  # area-weighting on by default
+    # pure VAR by default: t_glob exog whitens the noise and collapses
+    # low-frequency global variability
+    assert MeteorNoiseGenerator().use_exog == "none"
 
     # Test error handling with uninitiated state
     with pytest.raises(ValueError, match="Invalid use_exog value:"):


### PR DESCRIPTION
Pulling ben's exog fix into fastmip branch. Quick and dirty, no changelog/tests yet. 

Changes:
  - MeteorNoiseGenerator and train_*_from_cmip6 default use_exog 'temp_only'->'none'
  - interface _get_default_config: tas 'all'->'none' (pr was already 'none')
  - 'temp_only'/'all' retained for backward compatibility (documented as suppressing low-frequency global variability; 'temp_only' is also unstable at high lag_order)


- [ ] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [ ] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/benmsanderson/METEOR/pull/XX>`_) Added feature which does something``)
