### PR TITLE
Fit precipitation quantile map per month-of-year, full window

### DIFF
--- a/src/meteor/meteor_interface.py
+++ b/src/meteor/meteor_interface.py
@@ -1513,23 +1513,40 @@ class MeteorInterface:
                 if variable == "pr" and pr_baseline_agg is not None:
                     ensemble_for_transform = ensemble_for_transform + pr_baseline_agg
 
-                # Fit Gaussian to generated data
-                gaussian_params = transform_config.fit_1d_func(
-                    ensemble_for_transform, "gaussian"
+                # Fit per-month-of-year (seasonal) when the transform exposes it
+                # — otherwise σ_gaussian is dominated by the seasonal cycle and
+                # the quantile map squashes the inter-realization noise band.
+                use_seasonal = (
+                    transform_config.fit_1d_seasonal_func is not None
+                    and transform_config.apply_seasonal_func is not None
                 )
 
-                # Fit target distribution to CMIP6 data
-                target_params = transform_config.fit_1d_func(
-                    cmip6_agg, transform_config.transform_type
-                )
-
-                # Apply transform
-                transformed_ensemble = transform_config.apply_func(
-                    ensemble_for_transform,
-                    gaussian_params,
-                    target_params,
-                    target_dist=transform_config.transform_type,
-                )
+                if use_seasonal:
+                    gaussian_params = transform_config.fit_1d_seasonal_func(
+                        ensemble_for_transform, "gaussian"
+                    )
+                    target_params = transform_config.fit_1d_seasonal_func(
+                        cmip6_agg, transform_config.transform_type
+                    )
+                    transformed_ensemble = transform_config.apply_seasonal_func(
+                        ensemble_for_transform,
+                        gaussian_params,
+                        target_params,
+                        target_dist=transform_config.transform_type,
+                    )
+                else:
+                    gaussian_params = transform_config.fit_1d_func(
+                        ensemble_for_transform, "gaussian"
+                    )
+                    target_params = transform_config.fit_1d_func(
+                        cmip6_agg, transform_config.transform_type
+                    )
+                    transformed_ensemble = transform_config.apply_func(
+                        ensemble_for_transform,
+                        gaussian_params,
+                        target_params,
+                        target_dist=transform_config.transform_type,
+                    )
 
                 results[agg] = transformed_ensemble
             else:
@@ -1613,22 +1630,28 @@ class MeteorInterface:
         elif verbose:  # pragma: no cover
             print("      → Using shared stochastic PC realizations (gridded)")
 
-        # Resolve transform and (only for transform variables, e.g. pr) load the
-        # CMIP6 reference field and fit the per-gridpoint target distribution once.
+        # Resolve transform. For variables with a distribution transform (e.g.
+        # pr) we generate the full prediction window in one shot and apply the
+        # seasonal (per-month-of-year, per-gridpoint) transform once on the
+        # whole window. Doing it per year-slice (the old path) re-fitted the
+        # Gaussian on just 12 months at each gridpoint, which normalised every
+        # year to its own local mean and wiped the climate-change trend.
         transform_config = self._get_transform_config(variable)
+        pre_transformed_ensemble = None
         target_params = None
         pr_baseline_field = None
         if transform_config and transform_config.transform_type:
-            ssp_data, pr_baseline_field = self._load_transform_reference(
-                variable, start_year, end_year, verbose=verbose
-            )
-            if verbose:  # pragma: no cover
-                print(
-                    f"      → Fitting per-gridpoint {transform_config.transform_type} "
-                    "target distribution..."
-                )
-            target_params = transform_config.fit_3d_func(
-                ssp_data, transform_config.transform_type
+            pre_transformed_ensemble = self._build_full_window_transformed_ensemble(
+                variable,
+                monthly_prediction,
+                monthly_warming,
+                noise_model,
+                stochastic_pcs,
+                start_year,
+                end_year,
+                transform_config,
+                include_noise,
+                verbose=verbose,
             )
 
         # Extract requested time slices
@@ -1642,6 +1665,27 @@ class MeteorInterface:
         def year_to_month_idx(year):
             return (year - start_year) * 12
 
+        def _get_ensemble_slice(s_idx, e_idx, reduce_time):
+            """Slice the pre-transformed ensemble, or generate+transform per slice."""
+            if pre_transformed_ensemble is not None:
+                sliced = pre_transformed_ensemble.isel(month=slice(s_idx, e_idx))
+                if reduce_time:
+                    sliced = sliced.mean(dim="month")
+                return sliced
+            return self._generate_gridded_slice(
+                monthly_prediction,
+                monthly_warming,
+                noise_model,
+                stochastic_pcs,
+                s_idx,
+                e_idx,
+                include_noise,
+                reduce_time=reduce_time,
+                transform_config=transform_config,
+                target_params=target_params,
+                pr_baseline_field=pr_baseline_field,
+            )
+
         # Annual means (12-month average of each year)
         if "annual" in gridded_spec:
             if verbose:  # pragma: no cover
@@ -1653,18 +1697,8 @@ class MeteorInterface:
                 start_idx = year_to_month_idx(year)
                 end_idx = start_idx + 12
                 if start_idx >= 0 and end_idx <= n_months:
-                    annual_fields[year] = self._generate_gridded_slice(
-                        monthly_prediction,
-                        monthly_warming,
-                        noise_model,
-                        stochastic_pcs,
-                        start_idx,
-                        end_idx,
-                        include_noise,
-                        reduce_time=True,
-                        transform_config=transform_config,
-                        target_params=target_params,
-                        pr_baseline_field=pr_baseline_field,
+                    annual_fields[year] = _get_ensemble_slice(
+                        start_idx, end_idx, reduce_time=True
                     )
                 else:
                     if verbose:  # pragma: no cover
@@ -1684,18 +1718,8 @@ class MeteorInterface:
                 start_idx = year_to_month_idx(year)
                 end_idx = start_idx + 12
                 if start_idx >= 0 and end_idx <= n_months:
-                    monthly_fields[year] = self._generate_gridded_slice(
-                        monthly_prediction,
-                        monthly_warming,
-                        noise_model,
-                        stochastic_pcs,
-                        start_idx,
-                        end_idx,
-                        include_noise,
-                        reduce_time=False,
-                        transform_config=transform_config,
-                        target_params=target_params,
-                        pr_baseline_field=pr_baseline_field,
+                    monthly_fields[year] = _get_ensemble_slice(
+                        start_idx, end_idx, reduce_time=False
                     )
                 else:
                     if verbose:  # pragma: no cover
@@ -1718,19 +1742,7 @@ class MeteorInterface:
                     end_idx = year_to_month_idx(clim_end + 1)  # +1 to include end year
                     if start_idx >= 0 and end_idx <= n_months:
                         climatology_fields[f"{clim_start}-{clim_end}"] = (
-                            self._generate_gridded_slice(
-                                monthly_prediction,
-                                monthly_warming,
-                                noise_model,
-                                stochastic_pcs,
-                                start_idx,
-                                end_idx,
-                                include_noise,
-                                reduce_time=True,
-                                transform_config=transform_config,
-                                target_params=target_params,
-                                pr_baseline_field=pr_baseline_field,
-                            )
+                            _get_ensemble_slice(start_idx, end_idx, reduce_time=True)
                         )
                     else:
                         if verbose:  # pragma: no cover
@@ -1876,6 +1888,97 @@ class MeteorInterface:
         # Fit Gaussian per gridpoint to the generated ensemble, then map to target.
         gaussian_params = transform_config.fit_3d_func(data.values, "gaussian")
         transformed = transform_config.apply_func(
+            data.values,
+            gaussian_params,
+            target_params,
+            target_dist=transform_config.transform_type,
+        )
+        return xr.DataArray(transformed, coords=data.coords, dims=data.dims)
+
+    def _build_full_window_transformed_ensemble(
+        self,
+        variable,
+        monthly_prediction,
+        monthly_warming,
+        noise_model,
+        stochastic_pcs,
+        start_year,
+        end_year,
+        transform_config,
+        include_noise,
+        verbose=True,
+    ):
+        """
+        Generate the gridded ensemble over the FULL prediction window and apply
+        the seasonal (per-month-of-year, per-gridpoint) distribution transform
+        once.
+
+        Fitting the Gaussian half of the quantile map over the full window — and
+        per month-of-year rather than across all months at once — keeps the
+        long-term trend in the variance the map carries through (so the gridded
+        trend is preserved) while removing the seasonal cycle from σ (so the
+        inter-realization noise band is preserved at every gridpoint).
+
+        Returns
+        -------
+        xr.DataArray
+            Transformed monthly ensemble (realization, month, lat, lon) spanning
+            ``start_year..end_year`` inclusive. Callers slice this once per
+            requested annual / monthly / climatology field.
+        """
+        if verbose:  # pragma: no cover
+            print(
+                "      → Generating full-window gridded ensemble for "
+                f"{transform_config.transform_type} transform"
+            )
+
+        ssp_data, pr_baseline_field = self._load_transform_reference(
+            variable, start_year, end_year, verbose=verbose
+        )
+
+        if verbose:  # pragma: no cover
+            print(
+                f"      → Fitting per-month-of-year per-gridpoint "
+                f"{transform_config.transform_type} target distribution..."
+            )
+        target_params = transform_config.fit_3d_seasonal_func(
+            ssp_data, transform_config.transform_type
+        )
+
+        if include_noise:
+            realizations = noise_model.generate_realization(
+                monthly_warming,
+                noise_only=True,
+                add_base=monthly_prediction,
+                stochastic_pcs=stochastic_pcs,
+            )
+            if not isinstance(realizations, list):
+                realizations = [realizations]
+        else:
+            realizations = [monthly_prediction]
+        ensemble = _stack_realizations(realizations)
+
+        data = ensemble
+        if pr_baseline_field is not None:
+            extra_dims = [
+                d for d in pr_baseline_field.dims if d not in ("lat", "lon")
+            ]
+            if extra_dims:
+                pr_baseline_field = pr_baseline_field.isel(
+                    {d: 0 for d in extra_dims}, drop=True
+                )
+            data = data + pr_baseline_field
+
+        if verbose:  # pragma: no cover
+            print(
+                "      → Fitting per-month-of-year per-gridpoint Gaussian on "
+                "full-window generated ensemble..."
+            )
+        gaussian_params = transform_config.fit_3d_seasonal_func(
+            data.values, "gaussian"
+        )
+
+        transformed = transform_config.apply_seasonal_func(
             data.values,
             gaussian_params,
             target_params,

--- a/src/meteor/precipitation_transform.py
+++ b/src/meteor/precipitation_transform.py
@@ -369,6 +369,199 @@ def apply_distribution_transform(
 
 
 # =============================================================================
+# Seasonal (per-month-of-year) variants
+# =============================================================================
+#
+# Fitting/applying one quantile map across all months conflates the seasonal
+# cycle with internal variability: the Gaussian std becomes dominated by the
+# seasonal swing (very large for variables like precipitation), so the CDF
+# squashes inter-realization noise into a narrow quantile band and the gamma
+# PPF then maps it to a narrow output band. Fitting per month-of-year removes
+# the seasonal contribution from the variance the quantile map sees, so the
+# transform actually preserves the within-month internal variability.
+
+
+def _month_of_year_indices(n_time):
+    """Return a list of 12 index arrays selecting each month-of-year from a
+    contiguous monthly time axis of length ``n_time``. Assumes the series
+    starts in January; partial trailing years are fine (the last month-of-year
+    bins will just have one fewer sample)."""
+    return [np.arange(m, n_time, 12) for m in range(12)]
+
+
+def fit_distribution_parameters_1d_seasonal(timeseries_data, distribution="gamma"):
+    """
+    Fit a separate distribution per month-of-year (12 fits) to a 1D-time series.
+
+    Parameters
+    ----------
+    timeseries_data : np.ndarray or xr.DataArray
+        Monthly data. Last axis is time and must be a multiple of 12. Earlier
+        axes (realization / ensemble) are pooled into each per-month fit.
+    distribution : str
+        Distribution to fit at each month-of-year.
+
+    Returns
+    -------
+    dict
+        Each parameter key maps to a 1D array of length 12 (Jan..Dec).
+    """
+    if isinstance(timeseries_data, xr.DataArray):
+        data = timeseries_data.values
+    else:
+        data = timeseries_data
+
+    n_time = data.shape[-1]
+    month_idx = _month_of_year_indices(n_time)
+
+    per_month = [
+        fit_distribution_parameters_1d(data[..., idx], distribution=distribution)
+        for idx in month_idx
+    ]
+
+    keys = per_month[0].keys()
+    return {k: np.array([p[k] for p in per_month]) for k in keys}
+
+
+def fit_distribution_parameters_3d_seasonal(spatial_data, distribution="gamma"):
+    """
+    Fit per-gridpoint distributions separately for each month-of-year.
+
+    Parameters
+    ----------
+    spatial_data : np.ndarray or xr.DataArray
+        Shape (n_time, n_lat, n_lon) or (n_ensemble, n_time, n_lat, n_lon).
+        ``n_time`` must be a multiple of 12.
+    distribution : str
+        'gaussian' or 'gamma'.
+
+    Returns
+    -------
+    dict
+        Each parameter key maps to an array of shape (12, n_lat, n_lon).
+    """
+    if isinstance(spatial_data, xr.DataArray):
+        data = spatial_data.values
+    else:
+        data = spatial_data
+
+    if data.ndim == 3:
+        time_axis = 0
+        n_time = data.shape[0]
+    elif data.ndim == 4:
+        time_axis = 1
+        n_time = data.shape[1]
+    else:
+        raise ValueError(
+            "Data must be 3D (n_time, n_lat, n_lon) or "
+            f"4D (n_ensemble, n_time, n_lat, n_lon), got shape {data.shape}"
+        )
+
+    month_idx = _month_of_year_indices(n_time)
+
+    per_month = [
+        fit_distribution_parameters_3d(
+            np.take(data, idx, axis=time_axis), distribution=distribution
+        )
+        for idx in month_idx
+    ]
+
+    keys = per_month[0].keys()
+    return {k: np.stack([p[k] for p in per_month], axis=0) for k in keys}
+
+
+def apply_distribution_transform_seasonal(
+    gaussian_data, gaussian_params, target_params, target_dist="gamma"
+):
+    """
+    Apply a per-month-of-year quantile transform.
+
+    Automatically detects 1D vs 3D based on the rank of the parameter arrays
+    (``ndim == 1`` -> 1D scalar-per-month; ``ndim == 3`` -> 3D per-gridpoint).
+
+    Parameters
+    ----------
+    gaussian_data : np.ndarray or xr.DataArray
+        Shape (n_realizations, n_time) for 1D or
+        (n_realizations, n_time, n_lat, n_lon) / (n_time, n_lat, n_lon) for 3D.
+        ``n_time`` must be a multiple of 12.
+    gaussian_params, target_params : dict
+        Per-month-of-year parameter arrays. For 1D: shape (12,) each.
+        For 3D: shape (12, n_lat, n_lon) each.
+    target_dist : str
+        Target distribution name.
+
+    Returns
+    -------
+    Same type/shape as input.
+    """
+    is_xarray = isinstance(gaussian_data, xr.DataArray)
+    if is_xarray:
+        coords = gaussian_data.coords
+        dims = gaussian_data.dims
+        data = gaussian_data.values
+    else:
+        data = gaussian_data
+
+    sample_param = gaussian_params["mean"]
+    if sample_param.ndim == 1:
+        # 1D scalar-per-month
+        if data.ndim != 2:
+            raise ValueError(
+                "For 1D seasonal transform, expected 2D data (n_real, n_time), "
+                f"got shape {data.shape}"
+            )
+        time_axis = 1
+    elif sample_param.ndim == 3:
+        # 3D per-gridpoint-per-month: params shape (12, n_lat, n_lon)
+        if data.ndim == 3:
+            time_axis = 0
+        elif data.ndim == 4:
+            time_axis = 1
+        else:
+            raise ValueError(
+                "For 3D seasonal transform, expected 3D or 4D data, "
+                f"got shape {data.shape}"
+            )
+    else:
+        raise ValueError(
+            "Seasonal params must have ndim 1 (scalar per month) or 3 "
+            f"(per gridpoint per month), got ndim={sample_param.ndim}"
+        )
+
+    n_time = data.shape[time_axis]
+    month_idx = _month_of_year_indices(n_time)
+
+    transformed = np.empty_like(data, dtype=np.float64)
+    for m, idx in enumerate(month_idx):
+        data_m = np.take(data, idx, axis=time_axis)
+
+        if sample_param.ndim == 1:
+            # Extract Python scalars so the underlying apply_distribution_transform
+            # takes the 1D-scalar path (which uses np.isscalar).
+            gp_m = {k: float(v[m]) for k, v in gaussian_params.items()}
+            tp_m = {k: float(v[m]) for k, v in target_params.items()}
+        else:
+            gp_m = {k: v[m] for k, v in gaussian_params.items()}
+            tp_m = {k: v[m] for k, v in target_params.items()}
+
+        transformed_m = apply_distribution_transform(
+            data_m, gp_m, tp_m, target_dist=target_dist
+        )
+
+        # Write back into the appropriate slice of ``transformed``.
+        if time_axis == 0:
+            transformed[idx] = transformed_m
+        else:
+            # time_axis == 1 covers both 2D and 4D layouts.
+            transformed[:, idx] = transformed_m
+
+    if is_xarray:
+        return xr.DataArray(transformed, coords=coords, dims=dims)
+    return transformed
+
+
+# =============================================================================
 # Empirical Quantile Mapping (non-parametric alternative)
 # =============================================================================
 

--- a/src/meteor/variable_transforms.py
+++ b/src/meteor/variable_transforms.py
@@ -7,8 +7,11 @@ climate variables to ensure physical realism (e.g., precipitation positivity).
 
 from meteor.precipitation_transform import (
     apply_distribution_transform,
+    apply_distribution_transform_seasonal,
     fit_distribution_parameters_1d,
+    fit_distribution_parameters_1d_seasonal,
     fit_distribution_parameters_3d,
+    fit_distribution_parameters_3d_seasonal,
 )
 
 
@@ -30,6 +33,10 @@ class VariableTransformConfig:  # pylint: disable=too-few-public-methods
         Function to fit 3D transform parameters
     apply_func : callable, optional
         Function to apply the transform
+    fit_1d_seasonal_func, fit_3d_seasonal_func, apply_seasonal_func : callable, optional
+        Per-month-of-year variants. When present, the generator path uses these
+        in place of the pooled variants so the quantile map sees variability,
+        not the seasonal cycle.
     """
 
     def __init__(
@@ -40,6 +47,9 @@ class VariableTransformConfig:  # pylint: disable=too-few-public-methods
         fit_1d_func=None,
         fit_3d_func=None,
         apply_func=None,
+        fit_1d_seasonal_func=None,
+        fit_3d_seasonal_func=None,
+        apply_seasonal_func=None,
     ):
         self.name = name
         self.transform_type = transform_type
@@ -47,6 +57,9 @@ class VariableTransformConfig:  # pylint: disable=too-few-public-methods
         self.fit_1d_func = fit_1d_func
         self.fit_3d_func = fit_3d_func
         self.apply_func = apply_func
+        self.fit_1d_seasonal_func = fit_1d_seasonal_func
+        self.fit_3d_seasonal_func = fit_3d_seasonal_func
+        self.apply_seasonal_func = apply_seasonal_func
 
     def __repr__(self):
         """Return string representation of VariableTransformConfig."""
@@ -64,6 +77,9 @@ VARIABLE_TRANSFORMS = {
         fit_1d_func=fit_distribution_parameters_1d,
         fit_3d_func=fit_distribution_parameters_3d,
         apply_func=apply_distribution_transform,
+        fit_1d_seasonal_func=fit_distribution_parameters_1d_seasonal,
+        fit_3d_seasonal_func=fit_distribution_parameters_3d_seasonal,
+        apply_seasonal_func=apply_distribution_transform_seasonal,
     ),
     "tas": VariableTransformConfig(
         name=None,


### PR DESCRIPTION
The Gamma transform was conflating the seasonal cycle and the climate-change trend with internal variability:

  - Time-series path: the Gaussian was fit on the whole flattened (n_real, n_time) ensemble, so sigma was dominated by the wet/dry-season swing and the inter-realization noise band got squashed in the CDF→PPF roundtrip.
  - Gridded path: the transform was applied per year-slice, so the per- gridpoint Gaussian mean was the local 1-year climatology, which normalized every year to its own local distribution and wiped the climate-change trend at each gridpoint.

Fit and apply per month-of-year (12 fits) so the seasonal cycle lives in the per-month means instead of sigma, and on the gridded side build a single full-window transformed ensemble up front so the annual / monthly / climatology slicers just read from it. Old pooled fit/apply functions are kept for backwards compatibility; the seasonal variants are wired through VariableTransformConfig and only used when present.

<Please replace this paragraph by a description of what this PR does and alter the TODO-list below to what applies here. Please make a 'draft PR' to begin and then only mark it as ready for review once all the relevant points are done.>

- [ ] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [ ] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/benmsanderson/METEOR/pull/XX>`_) Added feature which does something``)
